### PR TITLE
Spec bump for swift 4.2 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ signalr-client/
 node_modules/
 TestServer/wwwroot/js/
 Pods/
+Package.resolved
+.build/

--- a/Podfile
+++ b/Podfile
@@ -1,3 +1,5 @@
+project 'SignalRClient.xcodeproj'
+
 target 'HubSample' do
   use_frameworks!
   platform :osx, '10.13'

--- a/SwiftSignalRClient.podspec
+++ b/SwiftSignalRClient.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name                   = "SwiftSignalRClient"
-  s.version                = "0.4.1"
+  s.version                = "0.4.2"
   s.summary                = "Swift SignalR Client for the ASP.Net Core version of SignalR."
   s.homepage               = "https://github.com/moozzyk/SignalR-Client-Swift"
   s.license                = { :type => "Attribution License", :file => "LICENSE" }
-  s.source                 = { :git => "https://github.com/moozzyk/SignalR-Client-Swift.git", :tag => "0.4.1" }
+  s.source                 = { :git => "https://github.com/moozzyk/SignalR-Client-Swift.git", :tag => "0.4.2" }
   s.authors                = { "Pawel Kadluczka" => "moozzyk@gmail.com" }
   s.social_media_url       = "https://twitter.com/moozzyk"
   s.swift_version          = "4.2"


### PR DESCRIPTION
With the Release of Swift 5, the previous Cocoapod - compiled with 3.3 - is no longer able to be integrated into projects. The minimum supported versions are 4.0, 4.2, and 5.0.

This PR is an addition to the changes I made previously, but would require a new push of the pod to the trunk.