### PR TITLE
Expose ConnectionId on HubConnection

### DIFF
--- a/Sources/SignalRClient/Connection.swift
+++ b/Sources/SignalRClient/Connection.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public protocol Connection {
     var delegate: ConnectionDelegate! {get set}
+    var connectionId: String? {get}
     func start() -> Void
     func send(data: Data, sendDidComplete: (_ error: Error?) -> Void) -> Void
     func stop(stopError: Error?) -> Void

--- a/Sources/SignalRClient/HttpConnection.swift
+++ b/Sources/SignalRClient/HttpConnection.swift
@@ -24,6 +24,7 @@ public class HttpConnection: Connection {
     private var stopError: Error?
 
     public weak var delegate: ConnectionDelegate!
+    public private(set) var connectionId: String?
 
     private enum State: String {
         case initial = "initial"
@@ -135,6 +136,7 @@ public class HttpConnection: Connection {
             return
         }
 
+        self.connectionId = negotiationResponse.connectionId
         let startUrl = self.createStartUrl(connectionId: negotiationResponse.connectionId)
         self.transport!.delegate = self.transportDelegate
         self.transport!.start(url: startUrl, options: self.options)
@@ -151,7 +153,9 @@ public class HttpConnection: Connection {
         if changeState {
             _ = self.changeState(from: nil, to: .stopped)
         }
-
+        
+        self.connectionId = nil
+        
         if leaveStartDispatchGroup {
             logger.log(logLevel: .debug, message: "Leaving startDispatchGroup (\(#function): \(#line))")
             startDispatchGroup.leave()
@@ -187,6 +191,8 @@ public class HttpConnection: Connection {
             return
         }
 
+        self.connectionId = nil
+        
         self.startDispatchGroup.wait()
         
         // The transport can be nil if connection was stopped immediately after starting
@@ -233,6 +239,8 @@ public class HttpConnection: Connection {
         let previousState = changeState(from: nil, to: .stopped)
         logger.log(logLevel: .debug, message: "Previous state \(previousState!)")
 
+        self.connectionId = nil
+        
         if previousState == .connecting {
             logger.log(logLevel: .debug, message: "Leaving startDispatchGroup (\(#function): \(#line))")
             // unblock the dispatch group if transport closed when starting (likely due to an error)

--- a/Sources/SignalRClient/HubConnection.swift
+++ b/Sources/SignalRClient/HubConnection.swift
@@ -20,6 +20,13 @@ public class HubConnection: ConnectionDelegate {
     private var connection: Connection
     private var hubProtocol: HubProtocol
     public weak var delegate: HubConnectionDelegate?
+    
+    /**
+     Gets the connections connectionId. This value will be cleared when the connection is stopped and will have a new value every time the connection is successfully started.
+     */
+    public var connectionId: String? {
+        return connection.connectionId
+    }
 
     public init(connection: Connection, hubProtocol: HubProtocol, logger: Logger = NullLogger()) {
         self.connection = connection

--- a/Tests/SignalRClientTests/HttpConnectionTests.swift
+++ b/Tests/SignalRClientTests/HttpConnectionTests.swift
@@ -615,4 +615,32 @@ class HttpConnectionTests: XCTestCase {
 
         waitForExpectations(timeout: 5 /*seconds*/)
     }
+
+    func testThatConnectionIdIsAvailableAfterStart() {
+        let httpConnectionOptions = HttpConnectionOptions()
+        let httpConnection = HttpConnection(url: URL(string:"http://fakeuri.org/")!, options: httpConnectionOptions, logger: PrintLogger())
+        let httpClient = TestHttpClient(postHandler: { _ in
+            return (HttpResponse(statusCode: 200, contents: self.negotiatePayload.data(using: .utf8)!), nil)
+        })
+        httpConnectionOptions.httpClientFactory = { options in httpClient }
+        
+        let connectionDelegate = TestConnectionDelegate()
+        connectionDelegate.connectionDidOpenHandler = { connection in
+            XCTAssertEqual("6baUtSEmluCoKvmUIqLUJw", connection.connectionId)
+            httpConnection.stop();
+        }
+        connectionDelegate.connectionDidCloseHandler = { error in
+            XCTAssertNil(httpConnection.connectionId)
+        }
+        
+        connectionDelegate.connectionDidFailToOpenHandler = { error in
+            XCTAssertNil(httpConnection.connectionId)
+        }
+        
+        httpConnection.delegate = connectionDelegate
+        
+        httpConnection.start()
+        
+        waitForExpectations(timeout: 5 /*seconds*/)
+    }
 }


### PR DESCRIPTION
I've added _connectionId_ property into the _hubConnection_, so users can get current connection id from the connection instance as it's done in Java and JS library.

HttpConnection test added.

Please merge into master.