### PR TITLE
JSONHubProtocol configure with JSONEncoder and JSONDecoder

### DIFF
--- a/Sources/SignalRClient/JSONHubProtocol.swift
+++ b/Sources/SignalRClient/JSONHubProtocol.swift
@@ -10,15 +10,19 @@ import Foundation
 
 public class JSONHubProtocol: HubProtocol {
     private static let recordSeparator = UInt8(0x1e)
-    private let encoder = JSONEncoder()
-    private let decoder = JSONDecoder()
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
     private let logger: Logger
     public let name = "json"
     public let version = 1
     public let type = ProtocolType.Text
 
-    public init(logger: Logger) {
+    public init(logger: Logger,
+                encoder: JSONEncoder = JSONEncoder(),
+                decoder: JSONDecoder = JSONDecoder()) {
         self.logger = logger
+        self.encoder = encoder
+        self.decoder = decoder
     }
 
     public func parseMessages(input: Data) throws -> [HubMessage] {


### PR DESCRIPTION
Hi, we need this extension because JSONEncoder and JSONDecoder has different dateDecodingStrategy or dateEncodingStrategy. 
So on custom payload we must support our date format
Another way of solving this issue was subclass JSONHubProtocol, but it little bit complicated because of public class instead of open,  internal PingMessage, custom Logger function and private params.
Or create own HubProtocol implementation with lots of parse logic, that already written in JSONHubProtocol