### PR TITLE
Fix builds using Swift Package Manager

### DIFF
--- a/Sources/SignalRClient/WebSocket.swift
+++ b/Sources/SignalRClient/WebSocket.swift
@@ -10,6 +10,9 @@
  */
 
 import Foundation
+#if canImport(zlib)
+import zlib
+#endif
 
 private let windowBufferSize = 0x2000
 


### PR DESCRIPTION
The project will build successfully if built directly, but if you use Swift Package Manager and include SignalR-Client-Swift as a dependency in another project, it will fail with unresolved symbol errors related to zlib. I've attached a simple sample project that proves the issue for easy reference.

[SignalR Test.zip](https://github.com/moozzyk/SignalR-Client-Swift/files/4309259/SignalR.Test.zip)
