### PR TITLE
Logger sending data as string

### DIFF
--- a/Sources/SignalRClient/HttpConnection.swift
+++ b/Sources/SignalRClient/HttpConnection.swift
@@ -177,7 +177,7 @@ public class HttpConnection: Connection {
     }
 
     public func send(data: Data, sendDidComplete: (_ error: Error?) -> Void) {
-        logger.log(logLevel: .debug, message: "Sending data")
+        logger.log(logLevel: .debug, message: "Sending data \(String(data: data, encoding: .utf8) ?? "(empty)")")
         if state != .connected {
             logger.log(logLevel: .error, message: "Sending data failed - connection not in the 'connected' state")
             sendDidComplete(SignalRError.invalidState)


### PR DESCRIPTION
It would be great to see what we sending after encoding message. 
Because now we build message, encode and send it at transport layer.
But to see it we can only on receiving side.

Сontroversial moment: Where print data? 
Entry point of receiving and sending messages is HttpConnection. 
But received message can be parsed in different way(recordSeparator usage and so on). So Logging parsed messages done in particular HubProtocol implementations.
So sending message data can be print in particular HubProtocol implementations in writeMessage function.

This implementation is done on HttpConnection as entry point. With printing separators and other stuff.

