### PR TITLE
Check for watchOS to ignore allowSelfSignedSSL

### DIFF
--- a/Sources/SignalRClient/WebSocket.swift
+++ b/Sources/SignalRClient/WebSocket.swift
@@ -1089,11 +1089,13 @@ private class InnerWebSocket: Hashable {
             rd.setProperty(StreamNetworkServiceTypeValue.voice.rawValue, forKey: Stream.PropertyKey.networkServiceType)
             wr.setProperty(StreamNetworkServiceTypeValue.voice.rawValue, forKey: Stream.PropertyKey.networkServiceType)
         }
+        #if !os(watchOS)
         if allowSelfSignedSSL {
             let prop: Dictionary<NSObject,NSObject> = [kCFStreamSSLPeerName: kCFNull, kCFStreamSSLValidatesCertificateChain: NSNumber(value: false)]
             rd.setProperty(prop, forKey: Stream.PropertyKey(rawValue: kCFStreamPropertySSLSettings as String as String))
             wr.setProperty(prop, forKey: Stream.PropertyKey(rawValue: kCFStreamPropertySSLSettings as String as String))
         }
+        #endif
         rd.delegate = delegate
         wr.delegate = delegate
         rd.schedule(in: RunLoop.main, forMode: RunLoop.Mode.default)


### PR DESCRIPTION
This was the only change I needed to make to get this running under watchOS. Given I can test on an iOS device against a self signed cert end point, I have no reason to test the same thing on watchOS, so it's an easy fix for a very large gain. I also played around with #if os(iOS) however this might cut out tvOS, which I have never tried. 
This change is due to the fact that kCFStreamSSLPeerName, kCFStreamSSLValidatesCertificateChain, kCFStreamPropertySSLSettings aren't available on watchOS.
There may be a better way to do what I've done, however in my testing so far its working spot on.