### PR TITLE
Make public constructor of HttpResponse

### DIFF
--- a/Sources/SignalRClient/HttpResponse.swift
+++ b/Sources/SignalRClient/HttpResponse.swift
@@ -26,7 +26,7 @@ public class HttpResponse {
     /**
      Initializes an `HttpResponse` with `statusCode` and `contents`.
      */
-    init(statusCode: Int, contents: Data?) {
+    public init(statusCode: Int, contents: Data?) {
         self.statusCode = statusCode
         self.contents = contents
     }


### PR DESCRIPTION
Now is not possible create own HttpClient using HttpClientProtocol because is not possible to create HttpResponse. #123 