### PR TITLE
Fixed a crash when using long polling on an older device with a 32 bit CPU

### DIFF
--- a/Sources/SignalRClient/LongPollingTransport.swift
+++ b/Sources/SignalRClient/LongPollingTransport.swift
@@ -140,7 +140,7 @@ public class LongPollingTransport: Transport {
         if components.queryItems == nil {
             components.queryItems = []
         }
-        let millisecondUnixTime = Int(Date().timeIntervalSince1970 * 1000)
+        let millisecondUnixTime = Int64(Date().timeIntervalSince1970 * 1000)
         components.queryItems?.append(URLQueryItem(name: "_", value: String(millisecondUnixTime)))
         let pollUrl = components.url
         return pollUrl!


### PR DESCRIPTION
Previously this would give "Fatal error: Double value cannot be converted to Int because the result would be greater than Int.max"