### PR TITLE
Fix a compiler warning in HubProtocol.swift

### DIFF
--- a/Sources/SignalRClient/HubProtocol.swift
+++ b/Sources/SignalRClient/HubProtocol.swift
@@ -215,7 +215,7 @@ public class PingMessage : HubMessage {
 }
 
 public class CloseMessage: HubMessage, Decodable {
-    public let type = MessageType.Close
+    public private(set) var type = MessageType.Close
     public let error: String?
 
     init(error: String?) {


### PR DESCRIPTION
Relates to https://github.com/moozzyk/SignalR-Client-Swift/issues/142 .