### PR TITLE
Support negotiateVersion

### DIFF
--- a/Tests/SignalRClientTests/HttpConnectionTests.swift
+++ b/Tests/SignalRClientTests/HttpConnectionTests.swift
@@ -540,7 +540,7 @@ class HttpConnectionTests: XCTestCase {
         let httpConnectionOptions = HttpConnectionOptions()
         let httpConnection = HttpConnection(url: URL(string:"http://fakeuri.org/")!, options: httpConnectionOptions, logger: PrintLogger())
         let httpClient = TestHttpClient(postHandler: { _ in
-            let negotiatePayload = "{\"connectionId\":\"6baUtSEmluCoKvmUIqLUJw\",\"availableTransports\":[]}"
+            let negotiatePayload = "{\"connectionId\":\"6baUtSEmluCoKvmUIqLUJw\",\"connectionToken\": \"9AnFxsjXqnRuz4UBt2W8\",\"negotiateVersion\":1,\"availableTransports\":[]}"
             return (HttpResponse(statusCode: 200, contents: negotiatePayload.data(using: .utf8)!), nil)
         })
         httpConnectionOptions.httpClientFactory = { options in httpClient }
@@ -557,7 +557,7 @@ class HttpConnectionTests: XCTestCase {
         waitForExpectations(timeout: 5 /*seconds*/)
     }
 
-    private let negotiatePayload = "{\"connectionId\":\"6baUtSEmluCoKvmUIqLUJw\",\"availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]},{\"transport\":\"ServerSentEvents\",\"transferFormats\":[\"Text\"]},{\"transport\":\"LongPolling\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"
+    private let negotiatePayload = "{\"connectionId\":\"6baUtSEmluCoKvmUIqLUJw\",\"connectionToken\": \"9AnFxsjXqnRuz4UBt2W8\",\"negotiateVersion\":1,\"availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]},{\"transport\":\"ServerSentEvents\",\"transferFormats\":[\"Text\"]},{\"transport\":\"LongPolling\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"
 
     private class TestTransportFactory: TransportFactory {
         let createTransport: () -> Transport
@@ -579,7 +579,7 @@ class HttpConnectionTests: XCTestCase {
 
         let httpConnectionOptions = HttpConnectionOptions()
         let httpClient = TestHttpClient(postHandler: { url in
-            if (url.absoluteString == initialUrl + "/negotiate") {
+            if (url.absoluteString == initialUrl + "/negotiate?negotiateVersion=1") {
                 let negotiatePayload = "{\"accessToken\":\"xyz\",\"url\":\"https://service/?abcdef\"}"
                 return (HttpResponse(statusCode: 200, contents: negotiatePayload.data(using: .utf8)!), nil)
             }
@@ -608,7 +608,7 @@ class HttpConnectionTests: XCTestCase {
     func testConnectionPassesConnectionIdWhenStartingTransport() {
         class ConnectionIdTransport: TestTransport {
             override func start(url: URL, options: HttpConnectionOptions) {
-                XCTAssertTrue(url.absoluteString.contains("?id=6baUtSEmluCoKvmUIqLUJw"))
+                XCTAssertTrue(url.absoluteString.contains("?id=9AnFxsjXqnRuz4UBt2W8"))
                 super.start(url: url, options: options)
             }
         }
@@ -648,7 +648,7 @@ class HttpConnectionTests: XCTestCase {
         
         let connectionDelegate = TestConnectionDelegate()
         connectionDelegate.connectionDidOpenHandler = { connection in
-            XCTAssertEqual("6baUtSEmluCoKvmUIqLUJw", connection.connectionId)
+            XCTAssertEqual("9AnFxsjXqnRuz4UBt2W8", connection.connectionId)
             connectionIdSetExpectation.fulfill()
             httpConnection.stop();
         }

--- a/Tests/SignalRClientTests/LongPollingTransportTests.swift
+++ b/Tests/SignalRClientTests/LongPollingTransportTests.swift
@@ -55,7 +55,7 @@ class LongPollingTransportTests: XCTestCase {
         // This is a simple implementation of the negotiation process to decouple this test from the real negotiation code.
         // This does not handle all possible circumstances but it works with the TestServer setup.
         let endpoint = ECHO_LONGPOLLING_URL.absoluteString
-        let negotiateUrl = URL(string: "\(endpoint)/negotiate")!
+        let negotiateUrl = URL(string: "\(endpoint)/negotiate?negotiateVersion=1")!
         var urlRequest = URLRequest(url: negotiateUrl)
         urlRequest.httpMethod = "POST"
         
@@ -75,10 +75,8 @@ class LongPollingTransportTests: XCTestCase {
         XCTAssertNotNil(responseData)
         
         let response = try! NegotiationPayloadParser.parse(payload: responseData) as! NegotiationResponse
-        let connectionId = response.connectionId
+        let connectionId = response.connectionToken
         let connectionUrl = URL(string: "\(endpoint)?id=\(connectionId)")!
         return connectionUrl
     }
-
-
 }

--- a/Tests/SignalRClientTests/NegotiationResponseTests.swift
+++ b/Tests/SignalRClientTests/NegotiationResponseTests.swift
@@ -15,14 +15,16 @@ class NegotiationResponseTests: XCTestCase {
         let availableTransports = [
             TransportDescription(transportType: .webSockets, transferFormats: [.text, .binary]),
             TransportDescription(transportType: .longPolling, transferFormats: [.binary])]
-        let negotiationResponse = NegotiationResponse(connectionId: "connectionId", availableTransports: availableTransports)
+        let negotiationResponse = NegotiationResponse(connectionId: "connectionId", connectionToken: "connectionToken", version: 42, availableTransports: availableTransports)
 
         XCTAssertEqual("connectionId", negotiationResponse.connectionId)
+        XCTAssertEqual("connectionToken", negotiationResponse.connectionToken)
+        XCTAssertEqual(42, negotiationResponse.version)
         XCTAssertTrue(availableTransports.elementsEqual(negotiationResponse.availableTransports) { $0 === $1 })
     }
 
     public func testThatParseCanParseCreatesNegotiationResponseFromValidPayload() {
-        let payload = "{\"connectionId\":\"6baUtSEmluCoKvmUIqLUJw\",\"availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]},{\"transport\":\"ServerSentEvents\",\"transferFormats\":[\"Text\"]},{\"transport\":\"LongPolling\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"
+        let payload = "{\"connectionId\":\"6baUtSEmluCoKvmUIqLUJw\",\"connectionToken\": \"9AnFxsjXqnRuz4UBt2W8\",\"negotiateVersion\":1,\"availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]},{\"transport\":\"ServerSentEvents\",\"transferFormats\":[\"Text\"]},{\"transport\":\"LongPolling\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"
 
         let negotiationResponse = try! NegotiationPayloadParser.parse(payload: payload.data(using: .utf8)) as! NegotiationResponse
 
@@ -60,14 +62,18 @@ class NegotiationResponseTests: XCTestCase {
             "[1]": "negotiation response is not a JSON object",
             "{}" : "connectionId property not found or invalid",
             "{\"connectionId\": []}" : "connectionId property not found or invalid",
-            "{\"connectionId\": \"123\"}" : "availableTransports property not found or invalid",
-            "{\"connectionId\": \"123\", \"availableTransports\": false}" : "availableTransports property not found or invalid",
-            "{\"connectionId\": \"123\", \"availableTransports\": [{}]}" : "transport property not found or invalid",
-            "{\"connectionId\": \"123\", \"availableTransports\": [{\"transport\": 42}]}" : "transport property not found or invalid",
-            "{\"connectionId\": \"123\", \"availableTransports\": [{\"transport\": \"WebSockets\"}]}" : "transferFormats property not found or invalid",
-            "{\"connectionId\": \"123\", \"availableTransports\": [{\"transport\": \"WebSockets\", \"transferFormats\":{}}]}" : "transferFormats property not found or invalid",
-            "{\"connectionId\": \"123\", \"availableTransports\": [{\"transport\": \"WebSockets\", \"transferFormats\":[]}]}" : "empty list of transfer formats",
-            "{\"connectionId\": \"123\", \"availableTransports\": [{\"transport\": \"WebSockets\", \"transferFormats\":[\"Text\", \"abc\"]}]}" : "invalid transfer format 'abc'",
+            "{\"connectionId\": \"123\" }" : "connectionToken property not found or invalid",
+            "{\"connectionId\": \"123\", \"connectionToken\": 1 }" : "connectionToken property not found or invalid",
+            "{\"connectionId\": \"123\", \"connectionToken\": \"9AnFxsjXqnRuz4UBt2W8\" }" : "negotiateVersion property not found or invalid",
+            "{\"connectionId\": \"123\", \"connectionToken\": \"9AnFxsjXqnRuz4UBt2W8\", \"negotiateVersion\": \"1\" }" : "negotiateVersion property not found or invalid",
+            "{\"connectionId\": \"123\", \"connectionToken\": \"9AnFxsjXqnRuz4UBt2W8\", \"negotiateVersion\": 1}" : "availableTransports property not found or invalid",
+            "{\"connectionId\": \"123\", \"connectionToken\": \"9AnFxsjXqnRuz4UBt2W8\", \"negotiateVersion\": 1,\"availableTransports\": false}" : "availableTransports property not found or invalid",
+            "{\"connectionId\": \"123\", \"connectionToken\": \"9AnFxsjXqnRuz4UBt2W8\", \"negotiateVersion\": 1, \"availableTransports\": [{}]}" : "transport property not found or invalid",
+            "{\"connectionId\": \"123\", \"connectionToken\": \"9AnFxsjXqnRuz4UBt2W8\", \"negotiateVersion\": 1,  \"availableTransports\": [{\"transport\": 42}]}" : "transport property not found or invalid",
+            "{\"connectionId\": \"123\",  \"connectionToken\": \"9AnFxsjXqnRuz4UBt2W8\", \"negotiateVersion\": 1, \"availableTransports\": [{\"transport\": \"WebSockets\"}]}" : "transferFormats property not found or invalid",
+            "{\"connectionId\": \"123\",  \"connectionToken\": \"9AnFxsjXqnRuz4UBt2W8\", \"negotiateVersion\": 1, \"availableTransports\": [{\"transport\": \"WebSockets\", \"transferFormats\":{}}]}" : "transferFormats property not found or invalid",
+            "{\"connectionId\": \"123\",  \"connectionToken\": \"9AnFxsjXqnRuz4UBt2W8\", \"negotiateVersion\": 1, \"availableTransports\": [{\"transport\": \"WebSockets\", \"transferFormats\":[]}]}" : "empty list of transfer formats",
+            "{\"connectionId\": \"123\",  \"connectionToken\": \"9AnFxsjXqnRuz4UBt2W8\", \"negotiateVersion\": 1, \"availableTransports\": [{\"transport\": \"WebSockets\", \"transferFormats\":[\"Text\", \"abc\"]}]}" : "invalid transfer format 'abc'",
             "{\"url\": 123}" : "url property not found or invalid",
             "{\"url\": \"123\"}" : "accessToken property not found or invalid",
             "{\"accessToken\": \"123\", \"url\": null}" : "url property not found or invalid",


### PR DESCRIPTION
SignalR allows to pass negotiateVersion to opt into new
behaviors/features. With negotiateVersion=1 connectionId is no longer
used to identify the connection. Instead, the client needs to use the
connectionToken it received in the negotiation response as the id