### PR TITLE
Fix flaky tests

### DIFF
--- a/Tests/SignalRClientTests/HttpConnectionTests.swift
+++ b/Tests/SignalRClientTests/HttpConnectionTests.swift
@@ -696,5 +696,4 @@ class HttpConnectionTests: XCTestCase {
 
         waitForExpectations(timeout: 5 /*seconds*/)
     }
-
 }


### PR DESCRIPTION
Fixing tests that failed when running againg Azure SignalR Service due
to races. There were two main issues:
- closing connection from client method handler instead of invocation
  completion handler
- closing connection from the server side which can be treated as
  graceful closure and hence not a subject to reconnect