### PR TITLE
Fix auto reconnect using overriden access token for negotiation

### DIFF
--- a/Sources/SignalRClient/HttpConnectionOptions.swift
+++ b/Sources/SignalRClient/HttpConnectionOptions.swift
@@ -33,11 +33,9 @@ public class HttpConnectionOptions {
      Whether to skip the negotiation request when starting a connection.
 
      - note: the negotiation request can be skipped only when using the WebSockets transport and cannot be skipped when connecting to SignalR Azure Service
-
     */
     public var skipNegotiation: Bool = false
 
-    
     /**
     The timeout value for individual requests, in seconds.
      */


### PR DESCRIPTION
The client was not able to reconnect to Azure SignalR Service if
the service required access token. The problem was that Azure SignalR
Service provides its own token during negotiation and the HttpConnection
overwrote the `accessTokenFactory` provided by the user by an internal
accessTokenFactory that returned the access token returned by Azure
SignalR Service during negotiation. In case of a reconnect the factory
would not be reset and the initial negotiate request would use the
internal access token factory instead of the one provided by the user.
The ultimate issue was that the HttpConnection modified the instance
of HttpConnectionOptions provided by the user. The fix is to create a
shallow copy of HttpConnectionOptions provided by the user when creating
a new instance of HttpConnection so that HttpConnection can modify its
own copy without touching the original instance provided by the user.

Fixes: #131