### PR TITLE
Removes DispatchGroup.wait() when in connecting state

### DIFF
--- a/Sources/SignalRClient/HttpConnection.swift
+++ b/Sources/SignalRClient/HttpConnection.swift
@@ -204,7 +204,7 @@ public class HttpConnection: Connection {
             return
         }
 
-        if previousState == .initial {
+        if previousState == .initial || previousState == .connecting {
             logger.log(logLevel: .warning, message: "Connection not yet started")
             return
         }


### PR DESCRIPTION
This freeze issue appears when the sockets are trying to reconnect but the reconnecting should be canceled due to logout action.

It seems to me that this case was not handled by the SignalR library author.

I also believe that no additional cleanup is needed when stopping connection when it is in connecting state.

I've tested auto reconnecting feature after this fix and it works fine.