### PR TITLE
Fix tvOS build failure after migration to URLSessionWebSocketTask

### DIFF
--- a/Sources/SignalRClient/DefaultTransportFactory.swift
+++ b/Sources/SignalRClient/DefaultTransportFactory.swift
@@ -60,7 +60,7 @@ internal class DefaultTransportFactory: TransportFactory {
     
     /// Creates a Transport instance for the given (singular) transport type
     private func buildTransport(type: TransportType?) -> Transport? {
-        if #available(OSX 10.15, iOS 13.0, watchOS 6.0, *) {
+        if #available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
             if type == .webSockets {
                 logger.log(logLevel: .info, message: "Selected WebSockets transport")
                 return WebsocketsTransport(logger: logger)

--- a/Sources/SignalRClient/WebsocketsTransport.swift
+++ b/Sources/SignalRClient/WebsocketsTransport.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-@available(OSX 10.15, iOS 13.0, watchOS 6.0, *)
+@available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public class WebsocketsTransport: NSObject, Transport, URLSessionWebSocketDelegate {
     private let logger: Logger
     private let dispatchQueue = DispatchQueue(label: "SignalR.webSocketTransport.queue")


### PR DESCRIPTION
Build for tvOS fails with a bunch of error messages around URLSessionWebSocketTask as it's only available since tvOS 13.0. An example of error message is as follows: "'URLSessionWebSocketTask' is only available in tvOS 13.0 or newer". Tested on tvOS 14.7.
