### PR TITLE
Fix double semaphore wait. Enable keepAlive by default.

### DIFF
--- a/Sources/SignalRClient/HttpConnection.swift
+++ b/Sources/SignalRClient/HttpConnection.swift
@@ -26,7 +26,7 @@ public class HttpConnection: Connection {
     public weak var delegate: ConnectionDelegate?
     public private(set) var connectionId: String?
     public var inherentKeepAlive: Bool {
-        return transport!.inherentKeepAlive
+        return transport?.inherentKeepAlive ?? true
     }
 
     private enum State: String {

--- a/Sources/SignalRClient/HubConnectionOptions.swift
+++ b/Sources/SignalRClient/HubConnectionOptions.swift
@@ -14,7 +14,7 @@ public class HubConnectionOptions {
     /**
      Keep-alive interval in seconds. If nil keep-alive is disabled
      */
-    public var keepAliveInterval: Double? = nil
+    public var keepAliveInterval: Double? = 15
 
     /**
      Initializes `HubConnectionOptions`


### PR DESCRIPTION
For thread-safety we do not need the semaphore. Therefore I removed it and improved the DispatchItemHandling. (This should fix #208)
Also I fixed a nullpointer issue, which sometimes happend in the transport. 
