### PR TITLE
macOS Monterey Documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ node_modules/
 */TestServer/wwwroot/js/
 Pods/
 Package.resolved
+.swiftpm/
 .build/
 # This can be generated using: swift package generate-xcodeproj
 SwiftSignalRClient.xcodeproj

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ More detailed user's guide:
 
 There are several sample projects in the `Examples` folder. They include:
 
-  - [SignalRClient.xcworkspace](Examples/)
+  - [SignalRClient.xcodeproj](Examples/)
     
     An Xcode workspace that has compiled libraries for macOS (OSX) and iOS, along with the Application targets 'ConnectionSample', 'HubSample', and 'HubSamplePhone'.
     
@@ -101,16 +101,22 @@ There are several sample projects in the `Examples` folder. They include:
     To run, navigate to the `TestServer` folder and execute the following in the terminal:
     
     ```sh
-    npm install
+    % npm install
+    % dotnet run
     ```
     
-    ```C#
-    dotnet run
-    ```
+    When running the `TestServer` project on macOS Monterey (12.0 or greater), you may encounter the error: 
+    **"Failed to bind to address http://0.0.0.0:5000: address already in use."**. This is due to Apple now advertising an 'AirPlay Receiver' on that port.
+    This port can be freed by disabling the receiver: Navigate to _System Preferences > Sharing_ and uncheck _AirPlay Receiver_.
 
 ## Migration from versions before 0.6.0
 
-The way of handling serialization/deserialization of values sent/received from the server changed in version 0.6.0. The `TypeConverter` protocol has been removed in favor of the `Encodable`/`Decodable` protocols. The client now can serialize and send to the server any value that conforms to the `Encodable` protocol and is able to deserialize any value received from the server as long as the target type for the value conforms to the `Decodable` protocol (in most cases you don't need to distinguish between these protocols and you can just make your types conform to the `Codable` protocol. Also primitive types already conform to the `Codable` protocol so they work out of the box). One of the consequences of this change is that the signature of the client side method handlers changed and the code needs to be adjusted when moving to the version 0.6.0. Here is how:
+The way of handling serialization/deserialization of values sent/received from the server changed in version 0.6.0. The `TypeConverter` protocol has been 
+removed in favor of the `Encodable`/`Decodable` protocols. The client now can serialize and send to the server any value that conforms to the `Encodable` 
+protocol and is able to deserialize any value received from the server as long as the target type for the value conforms to the `Decodable` protocol (in most 
+cases you don't need to distinguish between these protocols and you can just make your types conform to the `Codable` protocol. Also primitive types already 
+conform to the `Codable` protocol so they work out of the box). One of the consequences of this change is that the signature of the client side method handlers 
+changed and the code needs to be adjusted when moving to the version 0.6.0. Here is how:
 
 Before version 0.6.0 registering a handler for the client side method could look like this:
 
@@ -134,11 +140,13 @@ Here is the summary of the changes:
 - remove the `typeConverter` parameter
 - replace `args` parameter with a list of actual parameters (make sure to provide parameter types)
 - remove calls to `typeConverter` methods
-- remove code to handle optional types (if applicabale)
+- remove code to handle optional types (if applicable)
 
-Note: if your client side method takes more than 8 parameters you will need to use a lower level primitve to add a handler for this method. 
+Note: if your client side method takes more than 8 parameters you will need to use a lower level primitive to add a handler for this method. 
 
-Version 0.6.0 also adds some syntactic sugar for the APIs to invoke server side hub methods (i.e. `invoke`, `send`, `stream`). This is not a breaking change - the old methods will continue to work but in version 0.6.0 you can now pass the values as separate arguments instead of creating an array which is much nicer. For instance nvoking a hub method:
+Version 0.6.0 also adds some syntactic sugar for the APIs to invoke server side hub methods (i.e. `invoke`, `send`, `stream`). This is not a breaking change - 
+the old methods will continue to work but in version 0.6.0 you can now pass the values as separate arguments instead of creating an array which is much nicer. 
+For instance invoking a hub method:
 
 ```Swift
 chatHubConnection?.invoke(method: "Broadcast", arguments: [name, message]) { error in
@@ -158,11 +166,13 @@ chatHubConnection?.invoke(method: "Broadcast", name, message) { error in
 }
 ```
 
-The new APIs support up to 8 parameters. If you have a hub method taking more than 8 parameters you will need to use a lower level primitives that take an array containing parameter values.
+The new APIs support up to 8 parameters. If you have a hub method taking more than 8 parameters you will need to use a lower level primitives that take an array 
+containing parameter values.
 
 ## Disclaimer
 
-I am providing code in the repository to you under an open source license. Because this is my personal repository, the license you receive to my code is from me and not my employer (Facebook)
+I am providing code in the repository to you under an open source license. Because this is my personal repository, the license you receive to my code is from me 
+and not my employer (Facebook)
 
 ## Hits
 [![HitCount](http://hits.dwyl.com/moozzyk/Signalr-Client-Swift.svg)](http://hits.dwyl.com/moozzyk/Signalr-Client-Swift)

--- a/Sources/SignalRClient/DefaultTransportFactory.swift
+++ b/Sources/SignalRClient/DefaultTransportFactory.swift
@@ -49,15 +49,6 @@ internal class DefaultTransportFactory: TransportFactory {
         return chosen
     }
     
-    /// Sets the chosen type to have lowest priority for future reconnect attempts, to allow fallback when a transport does not work properly, e.g. due to
-    /// network conditions.
-    private func recordChoice(_ choice: TransportType?) {
-        if let choice = choice {
-            orderOfPreference.removeAll(where: { $0 == choice })
-            orderOfPreference.append(choice)
-        }
-    }
-    
     /// Creates a Transport instance for the given (singular) transport type
     private func buildTransport(type: TransportType?) -> Transport? {
         if #available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {

--- a/Sources/SignalRClient/DefaultTransportFactory.swift
+++ b/Sources/SignalRClient/DefaultTransportFactory.swift
@@ -49,6 +49,15 @@ internal class DefaultTransportFactory: TransportFactory {
         return chosen
     }
     
+    /// Sets the chosen type to have lowest priority for future reconnect attempts, to allow fallback when a transport does not work properly, e.g. due to
+    /// network conditions.
+    private func recordChoice(_ choice: TransportType?) {
+        if let choice = choice {
+            orderOfPreference.removeAll(where: { $0 == choice })
+            orderOfPreference.append(choice)
+        }
+    }
+    
     /// Creates a Transport instance for the given (singular) transport type
     private func buildTransport(type: TransportType?) -> Transport? {
         if #available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {

--- a/Sources/SignalRClient/HttpConnection.swift
+++ b/Sources/SignalRClient/HttpConnection.swift
@@ -282,7 +282,7 @@ public class HttpConnection: Connection {
     private func changeState(from: State?, to: State) -> State? {
         var previousState: State? = nil
 
-        logger.log(logLevel: .debug, message: "Attempting to chage state from: '\(from?.rawValue ?? "(nil)")' to: '\(to)'")
+        logger.log(logLevel: .debug, message: "Attempting to change state from: '\(from?.rawValue ?? "(nil)")' to: '\(to)'")
         connectionQueue.sync {
             if from == nil || from == state {
                 previousState = state

--- a/Sources/SignalRClient/HttpConnectionOptions.swift
+++ b/Sources/SignalRClient/HttpConnectionOptions.swift
@@ -20,7 +20,8 @@ public class HttpConnectionOptions {
     /**
      A factory for creating access tokens that will be included in HTTP requests sent by the client.
 
-     - note: the factory will be called before each http request and will set the `Authorization` token value to: `Bearer {token-returned-by-factory}` unless the returned value is `nil` in which case the `Authorization` header will not be created
+     - note: the factory will be called before each http request and will set the `Authorization` token value to: `Bearer {token-returned-by-factory}` unless
+             the returned value is `nil` in which case the `Authorization` header will not be created
     */
     public var accessTokenProvider: () -> String? = { return nil }
 

--- a/Sources/SignalRClient/HubConnection.swift
+++ b/Sources/SignalRClient/HubConnection.swift
@@ -9,7 +9,8 @@
 import Foundation
 
 /**
-`HubConnection` is the client for interacting with SignalR server. It allows invoking server side hub methods and register handlers for client side methods that can be invoked from the server.
+`HubConnection` is the client for interacting with SignalR server. It allows invoking server side hub methods and register handlers for client side methods
+ that can be invoked from the server.
 
  - note: You need to maintain the reference to the `HubConnection` instance until the connection is stopped
  */
@@ -37,7 +38,8 @@ public class HubConnection {
     public weak var delegate: HubConnectionDelegate?
     
     /**
-     Gets the connections connectionId. This value will be cleared when the connection is stopped and will have a new value every time the connection is successfully started.
+     Gets the connections connectionId. This value will be cleared when the connection is stopped and will have a new value every time the connection is
+     successfully started.
      */
     public var connectionId: String? {
         return connection.connectionId
@@ -81,7 +83,7 @@ public class HubConnection {
 
     fileprivate func initiateHandshake() {
         logger.log(logLevel: .info, message: "Hub connection started")
-        // TODO: support custom protcols
+        // TODO: support custom protocols
         // TODO: add negative test (e.g. invalid protocol)
         let handshakeRequest = HandshakeProtocol.createHandshakeRequest(hubProtocol: hubProtocol)
         logger.log(logLevel: .debug, message: "Sending handshake request: \(handshakeRequest)")
@@ -128,11 +130,13 @@ public class HubConnection {
     /**
      Invokes a server side hub method in a fire-and-forget manner.
 
-     When a hub method is invoked in a fire-and-forget manner the client never receives any result of the invocation nor is notified about the invocation status.
+     When a hub method is invoked in a fire-and-forget manner the client never receives any result of the invocation nor is notified about the invocation
+     status.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter arguments: hub method arguments
-     - parameter sendDidComplete: a completion handler that allows to track whether the client was able to successfully initiate the invocation. If the invocation was successfully initiated the `error` will be `nil`. Otherwise the `error` will contain failure details
+     - parameter sendDidComplete: a completion handler that allows to track whether the client was able to successfully initiate the invocation. If the
+                                  invocation was successfully initiated the `error` will be `nil`. Otherwise the `error` will contain failure details
      - parameter error: contains failure details if the invocation was not initiated successfully. `nil` otherwise
      - note: Consider using typed `.send()` extension methods defined on the `HubConnectionExtensions` class.
      */
@@ -159,7 +163,10 @@ public class HubConnection {
     /**
      Invokes a server side hub method that does not return a result.
 
-     The `invoke` method invokes a server side hub method and returns the status of the invocation. The `error` parameter of the `invocationDidComplete` callback will be `nil` if the invocation was successful. Otherwise it will contain failue details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for example the connection was not connected when invoking the method), or remote - e.g. the hub method on the server side threw an exception.
+     The `invoke` method invokes a server side hub method and returns the status of the invocation. The `error` parameter of the `invocationDidComplete`
+     callback will be `nil` if the invocation was successful. Otherwise it will contain failure details. Note that the failure can be local - e.g. the
+     invocation was not initiated successfully (for example the connection was not connected when invoking the method), or remote - e.g. the hub method on the
+     server side threw an exception.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter arguments: hub method arguments
@@ -176,7 +183,10 @@ public class HubConnection {
     /**
      Invokes a server side hub method that returns a result.
 
-     The `invoke` method invokes a server side hub method and returns the result of the invocation or error. If the server side method completed successfully the `invocationDidComplete` callback will be called with the result returned by the method and `nil` error. Otherwise the `error` parameter of the `invocationDidComplete` callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
+     The `invoke` method invokes a server side hub method and returns the result of the invocation or error. If the server side method completed successfully
+     the `invocationDidComplete` callback will be called with the result returned by the method and `nil` error. Otherwise the `error` parameter of the
+     `invocationDidComplete` callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully
+     (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter arguments: hub method arguments
@@ -203,7 +213,10 @@ public class HubConnection {
 
      The `stream` method invokes a streaming server side hub method. It takes two callbacks
      - `streamItemReceived` - invoked each time a stream item is received
-     - `invocationDidComplete` - invoked when the invocation of the streaming method has completed. If the streaming method completed successfully or was cancelled the callback will be called with `nil` error. Otherwise the `error` parameter of the `invocationDidComplete` callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
+     - `invocationDidComplete` - invoked when the invocation of the streaming method has completed. If the streaming method completed successfully or was
+                                 cancelled the callback will be called with `nil` error. Otherwise the `error` parameter of the `invocationDidComplete`
+                                 callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully
+                                 (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter arguments: hub method arguments
@@ -353,7 +366,7 @@ public class HubConnection {
                     // no action required for ping messages
                     break
                 default:
-                    logger.log(logLevel: .error, message: "Usupported message type: \(incomingMessage.type.rawValue)")
+                    logger.log(logLevel: .error, message: "Unsupported message type: \(incomingMessage.type.rawValue)")
                 }
             }
         } catch {
@@ -487,7 +500,7 @@ public class HubConnection {
             logger.log(logLevel: .debug, message: "Send keep alive")
             connection.send(data: cachedPingMessage, sendDidComplete: { error in
                 if let error = error {
-                    self.logger.log(logLevel: .error, message: "Keep alive Error recevied \(error.localizedDescription)")
+                    self.logger.log(logLevel: .error, message: "Keep alive Error received \(error.localizedDescription)")
                 } else {
                     self.logger.log(logLevel: .debug, message: "Keep alive - Still alive")
                 }
@@ -568,7 +581,7 @@ public class ArgumentExtractor {
     }
 
     /**
-     Allows to check if there are more arguments to retrieve.
+     Checks if there are more arguments to retrieve.
 
      - returns: `true` if there are more arguments to retrieve. `false` otherwise
      */

--- a/Sources/SignalRClient/HubConnectionBuilder.swift
+++ b/Sources/SignalRClient/HubConnectionBuilder.swift
@@ -74,7 +74,8 @@ public class HubConnectionBuilder {
      Allows configuring `PrintLogger` logging.
 
      - parameter minLogLevel: minimum log level
-     - note: By default logging is disabled. When using this overload all log entries whose level is greater or equal than `minLogLevel` (with `debug` being the lowest logging level) will be written using the `print` function.
+     - note: By default logging is disabled. When using this overload all log entries whose level is greater or equal than `minLogLevel` (with `debug` being
+             the lowest logging level) will be written using the `print` function.
      */
     public func withLogging(minLogLevel: LogLevel) -> HubConnectionBuilder {
         logger = FilteringLogger(minLogLevel: minLogLevel, logger: PrintLogger())
@@ -95,7 +96,8 @@ public class HubConnectionBuilder {
     /**
      Allows setting a custom logger and the minimum log level.
 
-     The log entries sent to the custom logger will be prefiltered and the logger will receive only the entries whose whose log level is greator or equal than `minLogLevel`.
+     The log entries sent to the custom logger will be pre-filtered and the logger will receive only the entries whose whose log level is greater or equal
+     than `minLogLevel`.
 
      - parameter minLogLevel: minimum log level
      - parameter logger: custom logger
@@ -117,10 +119,11 @@ public class HubConnectionBuilder {
     }
 
     /**
-    Allows enablbing and configuring automatic reconnection in case the connection was closed
+    Allows enabling and configuring automatic reconnection in case the connection was closed
 
      - parameter reconnectPolicy: allows setting a reconnect policy that configures reconnection
-     - note: by default the connection is not reconnectable. Calling this method makes it reconnectable. If no `reconnectPolicy` is provided the `DefaultReconnectPolicy` will be used.
+     - note: by default the connection is not reconnectable. Calling this method makes it reconnectable. If no `reconnectPolicy` is provided the
+             `DefaultReconnectPolicy` will be used.
      */
     public func withAutoReconnect(reconnectPolicy: ReconnectPolicy = DefaultReconnectPolicy()) -> HubConnectionBuilder {
         self.reconnectPolicy = reconnectPolicy
@@ -128,7 +131,7 @@ public class HubConnectionBuilder {
     }
     
     /**
-     Sets which transport types are turned on. Defaults to all types availble. Currently, only websockets and long polling are implemented.
+     Sets which transport types are turned on. Defaults to all types available. Currently, only websockets and long polling are implemented.
      */
     public func withPermittedTransportTypes(_ permittedTransportTypes: TransportType) -> HubConnectionBuilder {
         self.permittedTransportTypes = permittedTransportTypes
@@ -136,7 +139,8 @@ public class HubConnectionBuilder {
     }
 
     /**
-    In case support for automatic reconnects  introduces issues this method allows to get to the previous behavior. It should be treated as an emergency measure only and will be removed in future versions.
+     In case support for automatic reconnects  introduces issues this method allows to get to the previous behavior. It should be treated as an emergency
+     measure only and will be removed in future versions.
      */
     public func withLegacyHttpConnection() -> HubConnectionBuilder {
         useLegacyHttpConnection = true

--- a/Sources/SignalRClient/HubConnectionDelegate.swift
+++ b/Sources/SignalRClient/HubConnectionDelegate.swift
@@ -11,7 +11,8 @@ import Foundation
 /**
  A protocol that allows receiving hub connection lifecycle event notifications.
 
- To receive hub connection lifecycle event notifications create a class that conforms to this protocol and register it using the `HubConnectionBuilder.withHubConnectionDelegate()` method.
+ To receive hub connection lifecycle event notifications create a class that conforms to this protocol and register it using the
+ `HubConnectionBuilder.withHubConnectionDelegate()` method.
 
  - note: The user is responsible for maintaining the reference to the delegate.
  */

--- a/Sources/SignalRClient/HubConnectionExtensions.swift
+++ b/Sources/SignalRClient/HubConnectionExtensions.swift
@@ -11,7 +11,10 @@ public extension HubConnection {
     /**
      Invokes a server side hub method with no parameters that does not return a result.
 
-     The `invoke` method invokes a server side hub method and returns the status of the invocation. The `error` parameter of the `invocationDidComplete` callback will be `nil` if the invocation was successful. Otherwise it will contain failue details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for example the connection was not connected when invoking the method), or remote - e.g. the hub method on the server side threw an exception.
+     The `invoke` method invokes a server side hub method and returns the status of the invocation. The `error` parameter of the `invocationDidComplete`
+     callback will be `nil` if the invocation was successful. Otherwise it will contain failure details. Note that the failure can be local - e.g. the
+     invocation was not initiated successfully (for example the connection was not connected when invoking the method), or remote - e.g. the hub method on the
+     server side threw an exception.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter invocationDidComplete: a completion handler that will be invoked when the invocation has completed
@@ -24,7 +27,10 @@ public extension HubConnection {
     /**
      Invokes a server side hub method with 1 parameter that does not return a result.
 
-     The `invoke` method invokes a server side hub method and returns the status of the invocation. The `error` parameter of the `invocationDidComplete` callback will be `nil` if the invocation was successful. Otherwise it will contain failue details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for example the connection was not connected when invoking the method), or remote - e.g. the hub method on the server side threw an exception.
+     The `invoke` method invokes a server side hub method and returns the status of the invocation. The `error` parameter of the `invocationDidComplete`
+     callback will be `nil` if the invocation was successful. Otherwise it will contain failure details. Note that the failure can be local - e.g. the
+     invocation was not initiated successfully (for example the connection was not connected when invoking the method), or remote - e.g. the hub method on the
+     server side threw an exception.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter arg1: first argument of the hub method
@@ -38,7 +44,10 @@ public extension HubConnection {
     /**
      Invokes a server side hub method with 2 parameters that does not return a result.
 
-     The `invoke` method invokes a server side hub method and returns the status of the invocation. The `error` parameter of the `invocationDidComplete` callback will be `nil` if the invocation was successful. Otherwise it will contain failue details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for example the connection was not connected when invoking the method), or remote - e.g. the hub method on the server side threw an exception.
+     The `invoke` method invokes a server side hub method and returns the status of the invocation. The `error` parameter of the `invocationDidComplete`
+     callback will be `nil` if the invocation was successful. Otherwise it will contain failure details. Note that the failure can be local - e.g. the
+     invocation was not initiated successfully (for example the connection was not connected when invoking the method), or remote - e.g. the hub method on the
+     server side threw an exception.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter arg1: first argument of the hub method
@@ -53,7 +62,10 @@ public extension HubConnection {
     /**
      Invokes a server side hub method with 3 parameters that does not return a result.
 
-     The `invoke` method invokes a server side hub method and returns the status of the invocation. The `error` parameter of the `invocationDidComplete` callback will be `nil` if the invocation was successful. Otherwise it will contain failue details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for example the connection was not connected when invoking the method), or remote - e.g. the hub method on the server side threw an exception.
+     The `invoke` method invokes a server side hub method and returns the status of the invocation. The `error` parameter of the `invocationDidComplete`
+     callback will be `nil` if the invocation was successful. Otherwise it will contain failure details. Note that the failure can be local - e.g. the
+     invocation was not initiated successfully (for example the connection was not connected when invoking the method), or remote - e.g. the hub method on the
+     server side threw an exception.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter arg1: first argument of the hub method
@@ -69,7 +81,10 @@ public extension HubConnection {
     /**
      Invokes a server side hub method with 4 parameters that does not return a result.
 
-     The `invoke` method invokes a server side hub method and returns the status of the invocation. The `error` parameter of the `invocationDidComplete` callback will be `nil` if the invocation was successful. Otherwise it will contain failue details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for example the connection was not connected when invoking the method), or remote - e.g. the hub method on the server side threw an exception.
+     The `invoke` method invokes a server side hub method and returns the status of the invocation. The `error` parameter of the `invocationDidComplete`
+     callback will be `nil` if the invocation was successful. Otherwise it will contain failure details. Note that the failure can be local - e.g. the
+     invocation was not initiated successfully (for example the connection was not connected when invoking the method), or remote - e.g. the hub method on the
+     server side threw an exception.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter arg1: first argument of the hub method
@@ -86,7 +101,10 @@ public extension HubConnection {
     /**
      Invokes a server side hub method with 5 parameters that does not return a result.
 
-     The `invoke` method invokes a server side hub method and returns the status of the invocation. The `error` parameter of the `invocationDidComplete` callback will be `nil` if the invocation was successful. Otherwise it will contain failue details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for example the connection was not connected when invoking the method), or remote - e.g. the hub method on the server side threw an exception.
+     The `invoke` method invokes a server side hub method and returns the status of the invocation. The `error` parameter of the `invocationDidComplete`
+     callback will be `nil` if the invocation was successful. Otherwise it will contain failure details. Note that the failure can be local - e.g. the
+     invocation was not initiated successfully (for example the connection was not connected when invoking the method), or remote - e.g. the hub method on the
+     server side threw an exception.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter arg1: first argument of the hub method
@@ -104,7 +122,10 @@ public extension HubConnection {
     /**
      Invokes a server side hub method with 6 parameters that does not return a result.
 
-     The `invoke` method invokes a server side hub method and returns the status of the invocation. The `error` parameter of the `invocationDidComplete` callback will be `nil` if the invocation was successful. Otherwise it will contain failue details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for example the connection was not connected when invoking the method), or remote - e.g. the hub method on the server side threw an exception.
+     The `invoke` method invokes a server side hub method and returns the status of the invocation. The `error` parameter of the `invocationDidComplete`
+     callback will be `nil` if the invocation was successful. Otherwise it will contain failure details. Note that the failure can be local - e.g. the
+     invocation was not initiated successfully (for example the connection was not connected when invoking the method), or remote - e.g. the hub method on the
+     server side threw an exception.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter arg1: first argument of the hub method
@@ -123,7 +144,10 @@ public extension HubConnection {
     /**
      Invokes a server side hub method with 7 parameters that does not return a result.
 
-     The `invoke` method invokes a server side hub method and returns the status of the invocation. The `error` parameter of the `invocationDidComplete` callback will be `nil` if the invocation was successful. Otherwise it will contain failue details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for example the connection was not connected when invoking the method), or remote - e.g. the hub method on the server side threw an exception.
+     The `invoke` method invokes a server side hub method and returns the status of the invocation. The `error` parameter of the `invocationDidComplete`
+     callback will be `nil` if the invocation was successful. Otherwise it will contain failure details. Note that the failure can be local - e.g. the
+     invocation was not initiated successfully (for example the connection was not connected when invoking the method), or remote - e.g. the hub method on the
+     server side threw an exception.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter arg1: first argument of the hub method
@@ -143,7 +167,10 @@ public extension HubConnection {
     /**
      Invokes a server side hub method with 8 parameters that does not return a result.
 
-     The `invoke` method invokes a server side hub method and returns the status of the invocation. The `error` parameter of the `invocationDidComplete` callback will be `nil` if the invocation was successful. Otherwise it will contain failue details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for example the connection was not connected when invoking the method), or remote - e.g. the hub method on the server side threw an exception.
+     The `invoke` method invokes a server side hub method and returns the status of the invocation. The `error` parameter of the `invocationDidComplete`
+     callback will be `nil` if the invocation was successful. Otherwise it will contain failure details. Note that the failure can be local - e.g. the
+     invocation was not initiated successfully (for example the connection was not connected when invoking the method), or remote - e.g. the hub method on the
+     server side threw an exception.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter arg1: first argument of the hub method
@@ -164,7 +191,10 @@ public extension HubConnection {
     /**
      Invokes a server side hub method with no parameters that returns a result.
 
-     The `invoke` method invokes a server side hub method and returns the result of the invocation or error. If the server side method completed successfully the `invocationDidComplete` callback will be called with the result returned by the method and `nil` error. Otherwise the `error` parameter of the `invocationDidComplete` callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
+     The `invoke` method invokes a server side hub method and returns the result of the invocation or error. If the server side method completed successfully
+     the `invocationDidComplete` callback will be called with the result returned by the method and `nil` error. Otherwise the `error` parameter of the
+     `invocationDidComplete` callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully
+     (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter resultType: the type of the result returned by the hub method
@@ -179,7 +209,10 @@ public extension HubConnection {
     /**
      Invokes a server side hub method with 1 parameter that returns a result.
 
-     The `invoke` method invokes a server side hub method and returns the result of the invocation or error. If the server side method completed successfully the `invocationDidComplete` callback will be called with the result returned by the method and `nil` error. Otherwise the `error` parameter of the `invocationDidComplete` callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
+     The `invoke` method invokes a server side hub method and returns the result of the invocation or error. If the server side method completed successfully
+     the `invocationDidComplete` callback will be called with the result returned by the method and `nil` error. Otherwise the `error` parameter of the
+     `invocationDidComplete` callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully
+     (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter arg1: first argument of the hub method
@@ -195,7 +228,10 @@ public extension HubConnection {
     /**
      Invokes a server side hub method with 2 parameters that returns a result.
 
-     The `invoke` method invokes a server side hub method and returns the result of the invocation or error. If the server side method completed successfully the `invocationDidComplete` callback will be called with the result returned by the method and `nil` error. Otherwise the `error` parameter of the `invocationDidComplete` callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
+     The `invoke` method invokes a server side hub method and returns the result of the invocation or error. If the server side method completed successfully
+     the `invocationDidComplete` callback will be called with the result returned by the method and `nil` error. Otherwise the `error` parameter of the
+     `invocationDidComplete` callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully
+     (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter arg1: first argument of the hub method
@@ -212,7 +248,10 @@ public extension HubConnection {
     /**
      Invokes a server side hub method with 3 parameters that returns a result.
 
-     The `invoke` method invokes a server side hub method and returns the result of the invocation or error. If the server side method completed successfully the `invocationDidComplete` callback will be called with the result returned by the method and `nil` error. Otherwise the `error` parameter of the `invocationDidComplete` callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
+     The `invoke` method invokes a server side hub method and returns the result of the invocation or error. If the server side method completed successfully
+     the `invocationDidComplete` callback will be called with the result returned by the method and `nil` error. Otherwise the `error` parameter of the
+     `invocationDidComplete` callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully
+     (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter arg1: first argument of the hub method
@@ -230,7 +269,10 @@ public extension HubConnection {
     /**
      Invokes a server side hub method with 4 parameters that returns a result.
 
-     The `invoke` method invokes a server side hub method and returns the result of the invocation or error. If the server side method completed successfully the `invocationDidComplete` callback will be called with the result returned by the method and `nil` error. Otherwise the `error` parameter of the `invocationDidComplete` callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
+     The `invoke` method invokes a server side hub method and returns the result of the invocation or error. If the server side method completed successfully
+     the `invocationDidComplete` callback will be called with the result returned by the method and `nil` error. Otherwise the `error` parameter of the
+     `invocationDidComplete` callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully
+     (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter arg1: first argument of the hub method
@@ -249,7 +291,10 @@ public extension HubConnection {
     /**
      Invokes a server side hub method with 5 parameters that returns a result.
 
-     The `invoke` method invokes a server side hub method and returns the result of the invocation or error. If the server side method completed successfully the `invocationDidComplete` callback will be called with the result returned by the method and `nil` error. Otherwise the `error` parameter of the `invocationDidComplete` callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
+     The `invoke` method invokes a server side hub method and returns the result of the invocation or error. If the server side method completed successfully
+     the `invocationDidComplete` callback will be called with the result returned by the method and `nil` error. Otherwise the `error` parameter of the
+     `invocationDidComplete` callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully
+     (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter arg1: first argument of the hub method
@@ -269,7 +314,10 @@ public extension HubConnection {
     /**
      Invokes a server side hub method with 6 parameters that returns a result.
 
-     The `invoke` method invokes a server side hub method and returns the result of the invocation or error. If the server side method completed successfully the `invocationDidComplete` callback will be called with the result returned by the method and `nil` error. Otherwise the `error` parameter of the `invocationDidComplete` callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
+     The `invoke` method invokes a server side hub method and returns the result of the invocation or error. If the server side method completed successfully
+     the `invocationDidComplete` callback will be called with the result returned by the method and `nil` error. Otherwise the `error` parameter of the
+     `invocationDidComplete` callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully
+     (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter arg1: first argument of the hub method
@@ -290,7 +338,10 @@ public extension HubConnection {
     /**
      Invokes a server side hub method with 7 parameters that returns a result.
 
-     The `invoke` method invokes a server side hub method and returns the result of the invocation or error. If the server side method completed successfully the `invocationDidComplete` callback will be called with the result returned by the method and `nil` error. Otherwise the `error` parameter of the `invocationDidComplete` callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
+     The `invoke` method invokes a server side hub method and returns the result of the invocation or error. If the server side method completed successfully
+     the `invocationDidComplete` callback will be called with the result returned by the method and `nil` error. Otherwise the `error` parameter of the
+     `invocationDidComplete` callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully
+     (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter arg1: first argument of the hub method
@@ -312,7 +363,10 @@ public extension HubConnection {
     /**
      Invokes a server side hub method with 8 parameters that returns a result.
 
-     The `invoke` method invokes a server side hub method and returns the result of the invocation or error. If the server side method completed successfully the `invocationDidComplete` callback will be called with the result returned by the method and `nil` error. Otherwise the `error` parameter of the `invocationDidComplete` callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
+     The `invoke` method invokes a server side hub method and returns the result of the invocation or error. If the server side method completed successfully
+     the `invocationDidComplete` callback will be called with the result returned by the method and `nil` error. Otherwise the `error` parameter of the
+     `invocationDidComplete` callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully
+     (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter arg1: first argument of the hub method
@@ -338,7 +392,8 @@ public extension HubConnection {
      When a hub method is invoked in a fire-and-forget manner the client never receives any result of the invocation nor is notified about the invocation status.
 
      - parameter method: the name of the server side hub method to invoke
-     - parameter sendDidComplete: a completion handler that allows to track whether the client was able to successfully initiate the invocation. If the invocation was successfully initiated the `error` will be `nil`. Otherwise the `error` will contain failure details
+     - parameter sendDidComplete: a completion handler that allows to track whether the client was able to successfully initiate the invocation. If the
+                                  invocation was successfully initiated the `error` will be `nil`. Otherwise the `error` will contain failure details
      - parameter error: contains failure details if the invocation was not initiated successfully. `nil` otherwise
      */
     func send(method: String, sendDidComplete: @escaping (_ error: Error?) -> Void = {_ in}) {
@@ -352,7 +407,8 @@ public extension HubConnection {
 
      - parameter method: the name of the server side hub method to invoke
      - parameter arg1: first argument of the hub method
-     - parameter sendDidComplete: a completion handler that allows to track whether the client was able to successfully initiate the invocation. If the invocation was successfully initiated the `error` will be `nil`. Otherwise the `error` will contain failure details
+     - parameter sendDidComplete: a completion handler that allows to track whether the client was able to successfully initiate the invocation. If the
+                                  invocation was successfully initiated the `error` will be `nil`. Otherwise the `error` will contain failure details
      - parameter error: contains failure details if the invocation was not initiated successfully. `nil` otherwise
      */
     func send<T1: Encodable>(method: String, _ arg1: T1, sendDidComplete: @escaping (_ error: Error?) -> Void = {_ in}) {
@@ -367,7 +423,8 @@ public extension HubConnection {
      - parameter method: the name of the server side hub method to invoke
      - parameter arg1: first argument of the hub method
      - parameter arg2: second argument of the hub method
-     - parameter sendDidComplete: a completion handler that allows to track whether the client was able to successfully initiate the invocation. If the invocation was successfully initiated the `error` will be `nil`. Otherwise the `error` will contain failure details
+     - parameter sendDidComplete: a completion handler that allows to track whether the client was able to successfully initiate the invocation. If the
+                                  invocation was successfully initiated the `error` will be `nil`. Otherwise the `error` will contain failure details
      - parameter error: contains failure details if the invocation was not initiated successfully. `nil` otherwise
      */
     func send<T1: Encodable, T2: Encodable>(method: String, _ arg1: T1, _ arg2: T2, sendDidComplete: @escaping (_ error: Error?) -> Void = {_ in}) {
@@ -383,7 +440,8 @@ public extension HubConnection {
      - parameter arg1: first argument of the hub method
      - parameter arg2: second argument of the hub method
      - parameter arg3: third argument of the hub method
-     - parameter sendDidComplete: a completion handler that allows to track whether the client was able to successfully initiate the invocation. If the invocation was successfully initiated the `error` will be `nil`. Otherwise the `error` will contain failure details
+     - parameter sendDidComplete: a completion handler that allows to track whether the client was able to successfully initiate the invocation. If the
+                                  invocation was successfully initiated the `error` will be `nil`. Otherwise the `error` will contain failure details
      - parameter error: contains failure details if the invocation was not initiated successfully. `nil` otherwise
      */
     func send<T1: Encodable, T2: Encodable, T3: Encodable>(method: String, _ arg1: T1, _ arg2: T2, _ arg3: T3, sendDidComplete: @escaping (_ error: Error?) -> Void = {_ in}) {
@@ -400,7 +458,8 @@ public extension HubConnection {
      - parameter arg2: second argument of the hub method
      - parameter arg3: third argument of the hub method
      - parameter arg4: fourth argument of the hub method
-     - parameter sendDidComplete: a completion handler that allows to track whether the client was able to successfully initiate the invocation. If the invocation was successfully initiated the `error` will be `nil`. Otherwise the `error` will contain failure details
+     - parameter sendDidComplete: a completion handler that allows to track whether the client was able to successfully initiate the invocation. If the
+                                  invocation was successfully initiated the `error` will be `nil`. Otherwise the `error` will contain failure details
      - parameter error: contains failure details if the invocation was not initiated successfully. `nil` otherwise
      */
     func send<T1: Encodable, T2: Encodable, T3: Encodable, T4: Encodable>(method: String, _ arg1: T1, _ arg2: T2, _ arg3: T3, _ arg4: T4, sendDidComplete: @escaping (_ error: Error?) -> Void = {_ in}) {
@@ -418,7 +477,8 @@ public extension HubConnection {
      - parameter arg3: third argument of the hub method
      - parameter arg4: fourth argument of the hub method
      - parameter arg5: fifth argument of the hub method
-     - parameter sendDidComplete: a completion handler that allows to track whether the client was able to successfully initiate the invocation. If the invocation was successfully initiated the `error` will be `nil`. Otherwise the `error` will contain failure details
+     - parameter sendDidComplete: a completion handler that allows to track whether the client was able to successfully initiate the invocation. If the
+                                  invocation was successfully initiated the `error` will be `nil`. Otherwise the `error` will contain failure details
      - parameter error: contains failure details if the invocation was not initiated successfully. `nil` otherwise
      */
     func send<T1: Encodable, T2: Encodable, T3: Encodable, T4: Encodable, T5: Encodable>(method: String, _ arg1: T1, _ arg2: T2, _ arg3: T3, _ arg4: T4, _ arg5: T5, sendDidComplete: @escaping (_ error: Error?) -> Void = {_ in}) {
@@ -437,7 +497,8 @@ public extension HubConnection {
      - parameter arg4: fourth argument of the hub method
      - parameter arg5: fifth argument of the hub method
      - parameter arg6: sixth argument of the hub method
-     - parameter sendDidComplete: a completion handler that allows to track whether the client was able to successfully initiate the invocation. If the invocation was successfully initiated the `error` will be `nil`. Otherwise the `error` will contain failure details
+     - parameter sendDidComplete: a completion handler that allows to track whether the client was able to successfully initiate the invocation. If the
+                                  invocation was successfully initiated the `error` will be `nil`. Otherwise the `error` will contain failure details
      - parameter error: contains failure details if the invocation was not initiated successfully. `nil` otherwise
      */
     func send<T1: Encodable, T2: Encodable, T3: Encodable, T4: Encodable, T5: Encodable, T6: Encodable>(method: String, _ arg1: T1, _ arg2: T2, _ arg3: T3, _ arg4: T4, _ arg5: T5, _ arg6: T6, sendDidComplete: @escaping (_ error: Error?) -> Void = {_ in}) {
@@ -457,7 +518,8 @@ public extension HubConnection {
      - parameter arg5: fifth argument of the hub method
      - parameter arg6: sixth argument of the hub method
      - parameter arg7: seventh argument of the hub method
-     - parameter sendDidComplete: a completion handler that allows to track whether the client was able to successfully initiate the invocation. If the invocation was successfully initiated the `error` will be `nil`. Otherwise the `error` will contain failure details
+     - parameter sendDidComplete: a completion handler that allows to track whether the client was able to successfully initiate the invocation. If the
+                                  invocation was successfully initiated the `error` will be `nil`. Otherwise the `error` will contain failure details
      - parameter error: contains failure details if the invocation was not initiated successfully. `nil` otherwise
      */
     func send<T1: Encodable, T2: Encodable, T3: Encodable, T4: Encodable, T5: Encodable, T6: Encodable, T7: Encodable>(method: String, _ arg1: T1, _ arg2: T2, _ arg3: T3, _ arg4: T4, _ arg5: T5, _ arg6: T6, _ arg7: T7, sendDidComplete: @escaping (_ error: Error?) -> Void = {_ in}) {
@@ -478,7 +540,8 @@ public extension HubConnection {
      - parameter arg6: sixth argument of the hub method
      - parameter arg7: seventh argument of the hub method
      - parameter arg8: eighth argument of the hub method
-     - parameter sendDidComplete: a completion handler that allows to track whether the client was able to successfully initiate the invocation. If the invocation was successfully initiated the `error` will be `nil`. Otherwise the `error` will contain failure details
+     - parameter sendDidComplete: a completion handler that allows to track whether the client was able to successfully initiate the invocation. If the
+                                  invocation was successfully initiated the `error` will be `nil`. Otherwise the `error` will contain failure details
      - parameter error: contains failure details if the invocation was not initiated successfully. `nil` otherwise
      */
     func send<T1: Encodable, T2: Encodable, T3: Encodable, T4: Encodable, T5: Encodable, T6: Encodable, T7: Encodable, T8: Encodable>(method: String, _ arg1: T1, _ arg2: T2, _ arg3: T3, _ arg4: T4, _ arg5: T5, _ arg6: T6, _ arg7: T7, _ arg8: T8, sendDidComplete: @escaping (_ error: Error?) -> Void = {_ in}) {
@@ -739,7 +802,10 @@ public extension HubConnection {
 
      The `stream` method invokes a streaming server side hub method. It takes two callbacks
      - `streamItemReceived` - invoked each time a stream item is received
-     - `invocationDidComplete` - invoked when the invocation of the streaming method has completed. If the streaming method completed successfully or was cancelled the callback will be called with `nil` error. Otherwise the `error` parameter of the `invocationDidComplete` callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
+     - `invocationDidComplete` - invoked when the invocation of the streaming method has completed. If the streaming method completed successfully or was
+                                 cancelled the callback will be called with `nil` error. Otherwise the `error` parameter of the `invocationDidComplete` callback
+                                 will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for
+                                 example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter streamItemReceived: a handler that will be invoked each time a stream item is received
@@ -760,7 +826,10 @@ public extension HubConnection {
 
      The `stream` method invokes a streaming server side hub method. It takes two callbacks
      - `streamItemReceived` - invoked each time a stream item is received
-     - `invocationDidComplete` - invoked when the invocation of the streaming method has completed. If the streaming method completed successfully or was cancelled the callback will be called with `nil` error. Otherwise the `error` parameter of the `invocationDidComplete` callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
+     - `invocationDidComplete` - invoked when the invocation of the streaming method has completed. If the streaming method completed successfully or was
+                                 cancelled the callback will be called with `nil` error. Otherwise the `error` parameter of the `invocationDidComplete` callback
+                                 will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for
+                                 example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter arg1: first argument of the hub method
@@ -782,7 +851,10 @@ public extension HubConnection {
 
      The `stream` method invokes a streaming server side hub method. It takes two callbacks
      - `streamItemReceived` - invoked each time a stream item is received
-     - `invocationDidComplete` - invoked when the invocation of the streaming method has completed. If the streaming method completed successfully or was cancelled the callback will be called with `nil` error. Otherwise the `error` parameter of the `invocationDidComplete` callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
+     - `invocationDidComplete` - invoked when the invocation of the streaming method has completed. If the streaming method completed successfully or was
+                                 cancelled the callback will be called with `nil` error. Otherwise the `error` parameter of the `invocationDidComplete` callback
+                                 will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for
+                                 example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter arg1: first argument of the hub method
@@ -805,7 +877,10 @@ public extension HubConnection {
 
      The `stream` method invokes a streaming server side hub method. It takes two callbacks
      - `streamItemReceived` - invoked each time a stream item is received
-     - `invocationDidComplete` - invoked when the invocation of the streaming method has completed. If the streaming method completed successfully or was cancelled the callback will be called with `nil` error. Otherwise the `error` parameter of the `invocationDidComplete` callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
+     - `invocationDidComplete` - invoked when the invocation of the streaming method has completed. If the streaming method completed successfully or was
+                                 cancelled the callback will be called with `nil` error. Otherwise the `error` parameter of the `invocationDidComplete` callback
+                                 will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for
+                                 example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter arg1: first argument of the hub method
@@ -829,7 +904,10 @@ public extension HubConnection {
 
      The `stream` method invokes a streaming server side hub method. It takes two callbacks
      - `streamItemReceived` - invoked each time a stream item is received
-     - `invocationDidComplete` - invoked when the invocation of the streaming method has completed. If the streaming method completed successfully or was cancelled the callback will be called with `nil` error. Otherwise the `error` parameter of the `invocationDidComplete` callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
+     - `invocationDidComplete` - invoked when the invocation of the streaming method has completed. If the streaming method completed successfully or was
+                                 cancelled the callback will be called with `nil` error. Otherwise the `error` parameter of the `invocationDidComplete` callback
+                                 will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for
+                                 example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter arg1: first argument of the hub method
@@ -854,7 +932,10 @@ public extension HubConnection {
 
      The `stream` method invokes a streaming server side hub method. It takes two callbacks
      - `streamItemReceived` - invoked each time a stream item is received
-     - `invocationDidComplete` - invoked when the invocation of the streaming method has completed. If the streaming method completed successfully or was cancelled the callback will be called with `nil` error. Otherwise the `error` parameter of the `invocationDidComplete` callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
+     - `invocationDidComplete` - invoked when the invocation of the streaming method has completed. If the streaming method completed successfully or was
+                                 cancelled the callback will be called with `nil` error. Otherwise the `error` parameter of the `invocationDidComplete` callback
+                                 will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for
+                                 example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter arg1: first argument of the hub method
@@ -880,7 +961,10 @@ public extension HubConnection {
 
      The `stream` method invokes a streaming server side hub method. It takes two callbacks
      - `streamItemReceived` - invoked each time a stream item is received
-     - `invocationDidComplete` - invoked when the invocation of the streaming method has completed. If the streaming method completed successfully or was cancelled the callback will be called with `nil` error. Otherwise the `error` parameter of the `invocationDidComplete` callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
+     - `invocationDidComplete` - invoked when the invocation of the streaming method has completed. If the streaming method completed successfully or was
+                                 cancelled the callback will be called with `nil` error. Otherwise the `error` parameter of the `invocationDidComplete` callback
+                                 will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for
+                                 example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter arg1: first argument of the hub method
@@ -907,7 +991,10 @@ public extension HubConnection {
 
      The `stream` method invokes a streaming server side hub method. It takes two callbacks
      - `streamItemReceived` - invoked each time a stream item is received
-     - `invocationDidComplete` - invoked when the invocation of the streaming method has completed. If the streaming method completed successfully or was cancelled the callback will be called with `nil` error. Otherwise the `error` parameter of the `invocationDidComplete` callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
+     - `invocationDidComplete` - invoked when the invocation of the streaming method has completed. If the streaming method completed successfully or was
+                                 cancelled the callback will be called with `nil` error. Otherwise the `error` parameter of the `invocationDidComplete` callback
+                                 will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for
+                                 example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter arg1: first argument of the hub method
@@ -935,7 +1022,10 @@ public extension HubConnection {
 
      The `stream` method invokes a streaming server side hub method. It takes two callbacks
      - `streamItemReceived` - invoked each time a stream item is received
-     - `invocationDidComplete` - invoked when the invocation of the streaming method has completed. If the streaming method completed successfully or was cancelled the callback will be called with `nil` error. Otherwise the `error` parameter of the `invocationDidComplete` callback will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
+     - `invocationDidComplete` - invoked when the invocation of the streaming method has completed. If the streaming method completed successfully or was
+                                 cancelled the callback will be called with `nil` error. Otherwise the `error` parameter of the `invocationDidComplete` callback
+                                 will contain failure details. Note that the failure can be local - e.g. the invocation was not initiated successfully (for
+                                 example the connection was not started when invoking the method), or remote - e.g. the hub method threw an error.
 
      - parameter method: the name of the server side hub method to invoke
      - parameter arg1: first argument of the hub method

--- a/Sources/SignalRClient/JSONHubProtocol.swift
+++ b/Sources/SignalRClient/JSONHubProtocol.swift
@@ -27,7 +27,7 @@ public class JSONHubProtocol: HubProtocol {
 
     public func parseMessages(input: Data) throws -> [HubMessage] {
         let payloads = input.split(separator: JSONHubProtocol.recordSeparator)
-        // do not try to parse the last payload if it is not terminated with record sparator
+        // do not try to parse the last payload if it is not terminated with record separator
         var count = payloads.count
         if count > 0 && input.last != JSONHubProtocol.recordSeparator {
             logger.log(logLevel: .warning, message: "Partial message received. Here be dragons...")

--- a/Sources/SignalRClient/ReconnectPolicy.swift
+++ b/Sources/SignalRClient/ReconnectPolicy.swift
@@ -11,7 +11,7 @@ import Foundation
  Contains information about the current reconnection attempt
  */
 public struct RetryContext {
-    /// The number on unsuccesful connect attempts for this reconnect
+    /// The number on unsuccessful connect attempts for this reconnect
     public let failedAttemptsCount: Int
     /// The time this reconnect started
     public let reconnectStartTime: Date
@@ -26,7 +26,7 @@ public protocol ReconnectPolicy {
     /**
      Returns the time interval when the next connect attempt should take place.
     - parameter retryContext: information about the current reconnection attempt
-    - returns: time interval when the next connect attempt should take place. Returning `.never` indicates that no further connect attemps should take place.
+    - returns: time interval when the next connect attempt should take place. Returning `.never` indicates that no further connect attempts should take place.
      */
     func nextAttemptInterval(retryContext: RetryContext) -> DispatchTimeInterval
 }
@@ -37,10 +37,11 @@ public protocol ReconnectPolicy {
 public class DefaultReconnectPolicy: ReconnectPolicy {
     let retryIntervals: [DispatchTimeInterval]
 
-    /*
+    /**
      Initializes a new `DefaultReconnectPolicy` with the provided retry time intervals.
      - parameter retryIntervals: an array of retry intervals. If not provided the following intervals will be used 0, 2, 10 and 30 seconds.
-     - note: when providing own `retryIntervals` the client will attempt to re-establish the connection at most as many times as the number of provided intervals. If this fails the connection will be stopped.
+     - note: when providing own `retryIntervals` the client will attempt to re-establish the connection at most as many times as the number of provided
+             intervals. If this fails the connection will be stopped.
      */
     public init(retryIntervals: [DispatchTimeInterval] = [.milliseconds(0), .seconds(2), .seconds(10), .seconds(30)]) {
         self.retryIntervals = retryIntervals

--- a/Sources/SignalRClient/ReconnectableConnection.swift
+++ b/Sources/SignalRClient/ReconnectableConnection.swift
@@ -94,7 +94,7 @@ internal class ReconnectableConnection: Connection {
 
         logger.log(logLevel: .debug, message: {
             let initialStates = from?.map{$0.rawValue}.joined(separator: ", ") ?? "(nil)"
-            return "Attempting to chage state from: '\(initialStates)' to: '\(to)'"
+            return "Attempting to change state from: '\(initialStates)' to: '\(to)'"
         }())
         connectionQueue.sync {
             if from?.contains(self.state) ?? true {

--- a/Sources/SignalRClient/StreamHandle.swift
+++ b/Sources/SignalRClient/StreamHandle.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /**
- A handle indentifying a stream.
+ A handle identifying a stream.
 
  The handle is returned by the `HubConnection.stream` method and is required to cancel an active stream invocation.
  */

--- a/Sources/SignalRClient/WebsocketsTransport.swift
+++ b/Sources/SignalRClient/WebsocketsTransport.swift
@@ -56,7 +56,7 @@ public class WebsocketsTransport: NSObject, Transport, URLSessionWebSocketDelega
         webSocketTask?.receive { result in
             switch result {
             case .failure(let error):
-                // This failure always occurrs when the task is cancelled. If the code
+                // This failure always occurs when the task is cancelled. If the code
                 // is not normalClosure this is a real error.
                 if self.webSocketTask?.closeCode != .normalClosure {
                     self.handleError(error: error)

--- a/Tests/SignalRClientTests/HandshakeProtocolTests.swift
+++ b/Tests/SignalRClientTests/HandshakeProtocolTests.swift
@@ -21,7 +21,7 @@ class HandshakeProtocolTests: XCTestCase {
         XCTAssertNil(HandshakeProtocol.parseHandshakeResponse(data: "{ }\u{1e}".data(using: .utf8)!).0)
     }
 
-    public func testThatHandshakeProtocolReturnsErroHandshakeResponse() {
+    public func testThatHandshakeProtocolReturnsErrorHandshakeResponse() {
         let (error, _) = HandshakeProtocol.parseHandshakeResponse(data: "{ \"error\": \"handshake failed\"}\u{1e}".data(using: .utf8)!)
         switch (error as? SignalRError) {
         case .handshakeError(let errorMessage)?:
@@ -33,7 +33,7 @@ class HandshakeProtocolTests: XCTestCase {
         }
     }
 
-    public func testThatHandshakeProtocolReturnsErroForUnexpectedResponse() {
+    public func testThatHandshakeProtocolReturnsErrorForUnexpectedResponse() {
         let testResponses = ["{ \"message\": \"hello\"}\u{1e}", "{ \"message\": \"hello\", \"answer\": 42 }\u{1e}", "[]\u{1e}"]
 
         testResponses.forEach {
@@ -49,12 +49,12 @@ class HandshakeProtocolTests: XCTestCase {
         }
     }
 
-    public func testThatHandshakeProtocolReturnsErroForInvalidJson() {
+    public func testThatHandshakeProtocolReturnsErrorForInvalidJson() {
         let error = HandshakeProtocol.parseHandshakeResponse(data: "{\u{1e}".data(using: .utf8)!)
         XCTAssertNotNil(error)
     }
 
-    public func testThatHandshakeProtocolReturnsErroForPartialHandshakePayload() {
+    public func testThatHandshakeProtocolReturnsErrorForPartialHandshakePayload() {
         let testResponses = ["", "{"]
 
         testResponses.forEach {

--- a/Tests/SignalRClientTests/HttpConnectionTests.swift
+++ b/Tests/SignalRClientTests/HttpConnectionTests.swift
@@ -458,7 +458,7 @@ class HttpConnectionTests: XCTestCase {
         connectionDelegate.connectionDidCloseHandler = { error in
             XCTAssertNotNil(error)
             XCTAssertTrue("\(error!)".contains("Code=-1011"))
-            // This test is not determinitstic and either of the handlers can be invoked
+            // This test is not deterministic and either of the handlers can be invoked
             didFailToOpenExpectation.fulfill()
         }
         httpConnection.delegate = connectionDelegate

--- a/Tests/SignalRClientTests/HubConnectionTests.swift
+++ b/Tests/SignalRClientTests/HubConnectionTests.swift
@@ -150,7 +150,7 @@ class HubConnectionTests: XCTestCase {
         waitForExpectations(timeout: 5 /*seconds*/)
     }
 
-    func testThatInvokingVoidHubMethodRetunsErrorIfInvokedBeforeHandshakeReceived() {
+    func testThatInvokingVoidHubMethodReturnsErrorIfInvokedBeforeHandshakeReceived() {
         let didOpenExpectation = expectation(description: "connection opened")
 
         let hubConnectionDelegate = TestHubConnectionDelegate()
@@ -786,7 +786,7 @@ class HubConnectionTests: XCTestCase {
         waitForExpectations(timeout: 5 /*seconds*/)
     }
 
-    func testThatSendRetunsErrorIfInvokedBeforeHandshakeReceived() {
+    func testThatSendReturnsErrorIfInvokedBeforeHandshakeReceived() {
         let didComplete = expectation(description: "test completed")
 
         let hubConnection = HubConnectionBuilder(url: TARGET_TESTHUB_URL).build()


### PR DESCRIPTION
A few things here:
* macOS documentation: macOS Monterey has an 'AirPlay Receiver' bound to port 5000 by default. Added instructions on disabling the receiver so the test server can start correctly.
* Comment wrapping: wrapped especially long comment lines to make it easier to read documentation in-line.
* Spelling corrections