### PR TITLE
.Net 6.0

### DIFF
--- a/Examples/TestServer/TestServer.csproj
+++ b/Examples/TestServer/TestServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="5.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="6.0.5" />
   </ItemGroup>
 
   <Target Name="CopyClient" BeforeTargets="AfterBuild">


### PR DESCRIPTION
Updated **TestServer** Target Framework to 'net6.0'.
[.NET 5.0](https://dotnet.microsoft.com/en-us/download/dotnet) is now out-of-support.