### PR TITLE
Avoid a synchronous callback which can deadlock the keep alive ping.

### DIFF
--- a/Sources/SignalRClient/HttpConnection.swift
+++ b/Sources/SignalRClient/HttpConnection.swift
@@ -192,7 +192,11 @@ public class HttpConnection: Connection {
         logger.log(logLevel: .debug, message: "Sending data")
         guard state == .connected else {
             logger.log(logLevel: .error, message: "Sending data failed - connection not in the 'connected' state")
-            sendDidComplete(SignalRError.invalidState)
+
+            // Never synchronously respond to avoid upstream deadlocks based on async assumptions
+            connectionQueue.async {
+                sendDidComplete(SignalRError.invalidState)
+            }
             return
         }
         transport!.send(data: data, sendDidComplete: sendDidComplete)


### PR DESCRIPTION
The `sendKeepAlivePing` function is called on the `hubConnectionQueue`, and the `resetKeepAlive` function needs to acquire this queue to do its work.

If `HttpConnection` calls its `sendDidComplete` function synchronously, this results in a deadlock since `resetKeepAlive` is called inside the `hubConnectionQueue`. This PR ensures that the disconnected state sends completion asynchronously.

Obviously, there are other ways to do this – I'm happy for you to change the queue or avoid the deadlock another way. This PR is as much an FYI as a solution.