### PR TITLE
Don't call `resetKeepAlive` in `connectionDidReceiveData`.

### DIFF
--- a/Sources/SignalRClient/HubConnection.swift
+++ b/Sources/SignalRClient/HubConnection.swift
@@ -347,9 +347,10 @@ public class HubConnection {
                 delegate?.connectionDidReconnect()
             } else {
                 delegate?.connectionDidOpen(hubConnection: self)
+                resetKeepAlive()
             }
         }
-        resetKeepAlive()
+
         do {
             let messages = try hubProtocol.parseMessages(input: data)
             for incomingMessage in messages {


### PR DESCRIPTION
Hi Pawel,

As I mentioned in my other PR, I'm investigating why our server is choosing to close socket connections periodically.

I'm trying an experiment where I've removed the call to `resetKeepAlive` in `connectionDidReceiveData`. At the moment, it appears that this change avoids the problem I was having.

I don't know if this is correct. I don't really know what communication the SignalR server is supposed to use to keep the connection alive. I'm not even totally sure how our server is configured (it's out of my control). But I wanted to let you know the result of my experiment.

Cheers,
Matt.