### PR TITLE
Avoid asynchronous callback on ReconnectableConnection, too.

### DIFF
--- a/Sources/SignalRClient/ReconnectableConnection.swift
+++ b/Sources/SignalRClient/ReconnectableConnection.swift
@@ -58,7 +58,9 @@ internal class ReconnectableConnection: Connection {
         logger.log(logLevel: .info, message: "Received send request")
         guard state != .reconnecting else {
             // TODO: consider buffering
-            sendDidComplete(SignalRError.connectionIsReconnecting)
+            connectionQueue.async {
+                sendDidComplete(SignalRError.connectionIsReconnecting)
+            }
             return
         }
         underlyingConnection.send(data: data, sendDidComplete: sendDidComplete)


### PR DESCRIPTION
This PR is a follow up to https://github.com/moozzyk/SignalR-Client-Swift/pull/238

After fixing that bug, we're now seeing a deadlock in our analytics in `ReconnectableConnection`. For exactly the same reasons as `HttpConnection`, an asynchronous callback from `ReconnectableConnection` can cause a deadlock with the `keepAlivePing` so the `sendDidComplete` should always be sent asynchronously.