### PR TITLE
Block setting skipNegotiation if webSocket transport is not available

### DIFF
--- a/Sources/SignalRClient/HttpConnectionOptions.swift
+++ b/Sources/SignalRClient/HttpConnectionOptions.swift
@@ -35,7 +35,13 @@ public class HttpConnectionOptions {
 
      - note: the negotiation request can be skipped only when using the WebSockets transport and cannot be skipped when connecting to SignalR Azure Service
     */
-    public var skipNegotiation: Bool = false
+    public var skipNegotiation: Bool {
+        get { return skipNegotiationValue }
+        
+        @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+        set { skipNegotiationValue = newValue }
+    }
+    private var skipNegotiationValue = false
 
     /**
     The timeout value for individual requests, in seconds.

--- a/Sources/SignalRClient/HubConnectionBuilder.swift
+++ b/Sources/SignalRClient/HubConnectionBuilder.swift
@@ -185,7 +185,9 @@ public class HubConnectionBuilder {
             httpConnectionOptionsCopy.headers = httpConnectionOptions.headers
             httpConnectionOptionsCopy.accessTokenProvider = httpConnectionOptions.accessTokenProvider
             httpConnectionOptionsCopy.httpClientFactory = httpConnectionOptions.httpClientFactory
-            httpConnectionOptionsCopy.skipNegotiation = httpConnectionOptions.skipNegotiation
+            if #available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
+                httpConnectionOptionsCopy.skipNegotiation = httpConnectionOptions.skipNegotiation
+            }
             httpConnectionOptionsCopy.requestTimeout = httpConnectionOptions.requestTimeout
             return HttpConnection(url: url, options: httpConnectionOptionsCopy, transportFactory: transportFactory, logger: logger)
         }


### PR DESCRIPTION
Websocket task is not supported on some older OSX, iOS, watchOS and tvOS versions and the client will fallback to longPolling. However it was still possible to set the `skipNegotiation` to `true` which forced creating a webSocket transport which failed because the webSocket transport was not supported. This change blocks the ability to set `skipNegotiation` if the webSocket transport is not supported.

Fixes: #252 