### PR TITLE
Fix incomplete delegate HubConnectionBuilder allocation

### DIFF
--- a/Sources/SignalRClient/HubConnectionBuilder.swift
+++ b/Sources/SignalRClient/HubConnectionBuilder.swift
@@ -190,6 +190,7 @@ public class HubConnectionBuilder {
             }
             httpConnectionOptionsCopy.requestTimeout = httpConnectionOptions.requestTimeout
             httpConnectionOptionsCopy.callbackQueue = httpConnectionOptions.callbackQueue
+            httpConnectionOptionsCopy.authenticationChallengeHandler = httpConnectionOptions.authenticationChallengeHandler
             return HttpConnection(url: url, options: httpConnectionOptionsCopy, transportFactory: transportFactory, logger: logger)
         }
         


### PR DESCRIPTION
Add authenticationChallengeHandler to httpConnectionOptionsCopy, otherwise completion handler is not called when used from client