### PR TITLE
Fixing a bug when stopping a disconnected connection

### DIFF
--- a/Sources/SignalRClient/ReconnectableConnection.swift
+++ b/Sources/SignalRClient/ReconnectableConnection.swift
@@ -71,12 +71,11 @@ internal class ReconnectableConnection: Connection {
 
     func stop(stopError: Error?) {
         logger.log(logLevel: .info, message: "Received connection stop request")
-        guard self.state != .disconnected else {
-            logger.log(logLevel: .warning, message: "Reconnectable connection is already in the disconnected state. Ignoring stop request")
-            return
+        if changeState(from: [.starting, .reconnecting, .running], to: .stopping) != nil {
+          underlyingConnection.stop(stopError: stopError)
+        } else {
+          logger.log(logLevel: .warning, message: "Reconnectable connection is already in the disconnected state. Ignoring stop request")
         }
-        _ = changeState(from: nil, to: .stopping)
-        underlyingConnection.stop(stopError: stopError)
     }
 
     private func startInternal() {

--- a/Sources/SignalRClient/ReconnectableConnection.swift
+++ b/Sources/SignalRClient/ReconnectableConnection.swift
@@ -71,6 +71,10 @@ internal class ReconnectableConnection: Connection {
 
     func stop(stopError: Error?) {
         logger.log(logLevel: .info, message: "Received connection stop request")
+        guard self.state != .disconnected else {
+            logger.log(logLevel: .warning, message: "Reconnectable connection is already in the disconnected state. Ignoring stop request")
+            return
+        }
         _ = changeState(from: nil, to: .stopping)
         underlyingConnection.stop(stopError: stopError)
     }


### PR DESCRIPTION
### Problem Description
I faced an issue when the connection gets a stop request when it is in the `disconnected` state. 
This could happen when switching the tab very quickly or getting the app in background and opening it quickly. 
The connection will then not be able to restart.

### Steps to reproduce

1. Start a connection

1. Stop the connection

1. Then call `stop()` again

1. Try to start the connection again : the connection could not be started, we get :

> Reconnectable connection not in the disconnected state. Ignoring start request

### Expected behaviour
The connection should be able to start again

### Debugging informations
When calling `stop()` (`ReconnectableConnection` class) for the second time, it will change the state directly to `stopping` (without checking the current state). 
Then it will call `underlyingConnection.stop(stopError: stopError)` 
In the stop function (`HttpConnection` class), it will check if the connection is in the `stopped` state and will print a log message without continuing the rest of the function , that is why we do not get any callback after that and the connection will remain in the `stopping` state forever.

### Suggested solution
Checking the current state of the connection before executing the stop process

### Related issues
This Pull Request might could be related to #204 and #86  
