### PR TITLE
add ability to specify the URLSessionWebSocketTask maximumMessageSize

### DIFF
--- a/Sources/SignalRClient/HttpConnectionOptions.swift
+++ b/Sources/SignalRClient/HttpConnectionOptions.swift
@@ -47,7 +47,14 @@ public class HttpConnectionOptions {
     The timeout value for individual requests, in seconds.
      */
     public var requestTimeout: TimeInterval = 120
-    
+
+    /**
+     The maximum number of bytes to buffer before the receive call fails with an error.
+
+     This value includes the sum of all bytes from continuation frames. Receive calls will fail once the task reaches this limit. (URLSessionWebSocketTask)
+    */
+    public var maximumWebsocketMessageSize: Int?
+
     public var authenticationChallengeHandler: ((_ session: URLSession, _ challenge: URLAuthenticationChallenge, _ completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void)?
 
     /**

--- a/Sources/SignalRClient/HubConnectionBuilder.swift
+++ b/Sources/SignalRClient/HubConnectionBuilder.swift
@@ -171,6 +171,7 @@ public class HubConnectionBuilder {
                 httpConnectionOptionsCopy.skipNegotiation = httpConnectionOptions.skipNegotiation
             }
             httpConnectionOptionsCopy.requestTimeout = httpConnectionOptions.requestTimeout
+            httpConnectionOptionsCopy.maximumWebsocketMessageSize = httpConnectionOptions.maximumWebsocketMessageSize
             httpConnectionOptionsCopy.callbackQueue = httpConnectionOptions.callbackQueue
             httpConnectionOptionsCopy.authenticationChallengeHandler = httpConnectionOptions.authenticationChallengeHandler
             return HttpConnection(url: url, options: httpConnectionOptionsCopy, transportFactory: transportFactory, logger: logger)

--- a/Sources/SignalRClient/WebsocketsTransport.swift
+++ b/Sources/SignalRClient/WebsocketsTransport.swift
@@ -35,7 +35,10 @@ public class WebsocketsTransport: NSObject, Transport, URLSessionWebSocketDelega
         setAccessToken(accessTokenProvider: options.accessTokenProvider, request: &request)
         urlSession = URLSession(configuration: .default, delegate: self, delegateQueue: OperationQueue())
         webSocketTask = urlSession!.webSocketTask(with: request)
-        
+        if let maximumWebsocketMessageSize = options.maximumWebsocketMessageSize {
+            webSocketTask?.maximumMessageSize = maximumWebsocketMessageSize
+        }
+
         webSocketTask!.resume()
     }
 


### PR DESCRIPTION
- exposes `maximumWebsocketMessageSize` via `HttpConnectionOptions` so that `maximumMessageSize` can be set on `URLSessionWebSocketTask`
- this is needed to be able to set larger buffer sizes than Apple's default