### PR TITLE
Added an InfiniteReconnectPolicy.

### DIFF
--- a/Sources/SignalRClient/ReconnectPolicy.swift
+++ b/Sources/SignalRClient/ReconnectPolicy.swift
@@ -60,3 +60,26 @@ internal class NoReconnectPolicy: ReconnectPolicy {
         return DispatchTimeInterval.never
     }
 }
+
+/**
+ Infinite reconnect policy that allows providing custom intervals for connect attempts.
+ Does not stop when last interval was reached, instead repeats last interval infinitely.
+ */
+public class InfiniteReconnectPolicy: ReconnectPolicy {
+    let retryIntervals: [DispatchTimeInterval]
+
+    /**
+     Initializes a new `InfiniteReconnectPolicy` with the provided retry time intervals.
+     - parameter retryIntervals: an array of retry intervals. If not provided the following intervals will be used 0, 2, 10 and 15 seconds.
+     */
+    public init(retryIntervals: [DispatchTimeInterval] = [.milliseconds(0), .seconds(2), .seconds(10), .seconds(15)]) {
+        self.retryIntervals = retryIntervals
+    }
+
+    public func nextAttemptInterval(retryContext: RetryContext) -> DispatchTimeInterval {
+        if retryContext.failedAttemptsCount >= retryIntervals.count {
+            return retryIntervals[retryIntervals.count - 1]
+        }
+        return retryIntervals[retryContext.failedAttemptsCount]
+    }
+}


### PR DESCRIPTION
Added `InfiniteReconnectPolicy` for systems that require reconnection whenever is possible. The `InfiniteReconnectPolicy` takes last `retryInterval` and repeats it infinitely, when last `retryInterval` was reached.

My team is using .NET with SignalR in the backend, and this ReconnectPolicy is crucial for our iOS app to work seamlessly. Therefore I'd appreciate this change being part of the original repository :)